### PR TITLE
Driving Overhaul

### DIFF
--- a/Assets/Prefabs/Car.prefab
+++ b/Assets/Prefabs/Car.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 5760145587032998370}
   - component: {fileID: 3786918790669288600}
   m_Layer: 0
-  m_Name: Mission Title
+  m_Name: MissionTitle
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2433,7 +2433,7 @@ MonoBehaviour:
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 0
-  m_FillAmount: 1
+  m_FillAmount: 0.989
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
@@ -2762,7 +2762,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8079628787971129701}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.05, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 5.583975, y: 5.449152, z: 1}
   m_Children: []
   m_Father: {fileID: 8079628788138018953}
@@ -2806,7 +2806,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 1
+  m_SortingOrder: 50
   m_Sprite: {fileID: 21300000, guid: 86b3a8c6bb3e36c448b711fc502e2fec, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -2828,8 +2828,9 @@ GameObject:
   m_Component:
   - component: {fileID: 8079628788138018953}
   - component: {fileID: 8079628788138018955}
-  - component: {fileID: 8079628788138018954}
   - component: {fileID: 8079628788138018964}
+  - component: {fileID: 1871149262}
+  - component: {fileID: 1871149263}
   m_Layer: 0
   m_Name: Car
   m_TagString: Car
@@ -2846,7 +2847,7 @@ Transform:
   m_GameObject: {fileID: 8079628788138018952}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 2.763708, y: -1.5284537, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.73279, y: 0.73279, z: 0.73279}
   m_Children:
   - {fileID: 8079628787971129702}
   - {fileID: 8079628787533786840}
@@ -2879,33 +2880,6 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 1
   m_Constraints: 0
---- !u!114 &8079628788138018954
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8079628788138018952}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c0bdfe09ac2064f10a227f6d40928c4f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  acceleration: 10
-  maxForwardSpeed: 10
-  maxReverseSpeed: 5
-  steeringSpeed: 150
-  bounceBackDistance: 1
-  bounceBackSpeed: 5
-  driftDrag: 0.05
-  normalDrag: 1
-  driftSteeringMultiplier: 2.5
-  driftSpeedBoost: 3
-  boostMultiplier: 2
-  boostDuration: 2
-  maxHealth: 100
-  collisionDamage: 20
-  healthBarSlider: {fileID: 8079628787390842740}
 --- !u!61 &8079628788138018964
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -2919,7 +2893,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
+  m_Offset: {x: 0, y: 0.09}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -2930,8 +2904,124 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 1.23, y: 2.53}
   m_EdgeRadius: 0
+--- !u!114 &1871149262
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8079628788138018952}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f07ec5a55dd767c488b2405c61af01cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  driftFactor: 0.4
+  accelerationFactor: 30
+  turnFactor: 3.5
+  baseMaxSpeed: 15
+  steeringRefSpeed: 20
+  steeringCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 3.3338103
+      outSlope: 3.3338103
+      tangentMode: 34
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.30026728
+      value: 1.0010341
+      inSlope: 1.8674407
+      outSlope: 0.09802438
+      tangentMode: 1
+      weightedMode: 3
+      inWeight: 0.5505101
+      outWeight: 0.7955603
+    - serializedVersion: 3
+      time: 1.001709
+      value: 0.39983368
+      inSlope: -0.85709256
+      outSlope: -0.85709256
+      tangentMode: 34
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  accelerationRefSpeed: 15
+  accelerationCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0.3
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 0.19311729
+      value: 0.8296327
+      inSlope: 65.137665
+      outSlope: 21.577143
+      tangentMode: 1
+      weightedMode: 3
+      inWeight: 0.04067028
+      outWeight: 0.053577937
+    - serializedVersion: 3
+      time: 0.27526855
+      value: 1.0087433
+      inSlope: -0.100053206
+      outSlope: 0.13564034
+      tangentMode: 1
+      weightedMode: 3
+      inWeight: 0.53181905
+      outWeight: 0.8076028
+    - serializedVersion: 3
+      time: 1
+      value: 0.2
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  maxHealth: 100
+  collisionDamage: 1
+  healthBarSlider: {fileID: 8079628787390842740}
+  boostMultiplier: 1.5
+  boostDrainRate: 25
+  maxBoost: 100
+  boostBarSlider: {fileID: 4551025498675915892}
+  driftSmokeSpawnPoint: {fileID: 8491513496611578308}
+  driftSmokeInterval: 0.05
+  gameController: {fileID: 0}
+  straightenSpeed: 5
+--- !u!114 &1871149263
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8079628788138018952}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 71548bc962324ff49b1041549c5448fc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &8079628788145642440
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Cop Car.prefab
+++ b/Assets/Prefabs/Cop Car.prefab
@@ -179,7 +179,7 @@ MonoBehaviour:
   driftFactor: 0.4
   accelerationFactor: 15
   turnFactor: 4
-  maxSpeed: 20
+  maxSpeed: 16
   stationaryThreshold: 1
   stationaryDuration: 1
   reverseDuration: 1

--- a/Assets/Scripts/CameraFollow2D.cs
+++ b/Assets/Scripts/CameraFollow2D.cs
@@ -6,10 +6,37 @@ public class CameraFollow2D : MonoBehaviour
     public float smoothSpeed = 5f;
     public Vector3 offset = new Vector3(0, 0, -10);
 
+    [Header("Zoom Settings")]
+    public float minZoom = 5f;     // zoomed in at low speed
+    public float maxZoom = 10f;    // zoomed out at high speed
+    public float zoomLerpSpeed = 5f;
+    public float speedForMaxZoom = 20f; // what speed counts as "full zoom out"
+
+    private Camera camera;
+    private Rigidbody2D targetRb;
+
+    void Awake()
+    {
+        camera = GetComponent<Camera>();
+        if (target != null)
+            targetRb = target.GetComponent<Rigidbody2D>();
+    }
     void LateUpdate()
     {
         if (target == null) return;
+
+        //Follow logic
         Vector3 desiredPosition = target.position + offset;
         transform.position = Vector3.Lerp(transform.position, desiredPosition, smoothSpeed * Time.deltaTime);
+
+        //Zoom logic
+        if (targetRb != null)
+        {
+            float speed = targetRb.velocity.magnitude;
+            float t = Mathf.Clamp01(speed / speedForMaxZoom);
+            float targetZoom = Mathf.Lerp(minZoom, maxZoom, t);
+
+            camera.orthographicSize = Mathf.Lerp(camera.orthographicSize, targetZoom, zoomLerpSpeed * Time.deltaTime);
+        }
     }
 }

--- a/Assets/Scripts/CarInputHandler.cs
+++ b/Assets/Scripts/CarInputHandler.cs
@@ -4,14 +4,14 @@ using UnityEngine;
 
 public class CarInputHandler : MonoBehaviour
 {
-    PhysicsPlayerCarController carController;
+    PhysicsPlayerCarController2 carController;
 
     void Awake()
     {
         // controlled car machanics
-        carController = GetComponent<PhysicsPlayerCarController>();
+        //carController = GetComponent<PhysicsPlayerCarController>();
         // UnControlled car machanics 
-        // carController = GetComponent<PhysicsPlayerCarController2>();    
+        carController = GetComponent<PhysicsPlayerCarController2>();    
     }
 
     // Start is called before the first frame update

--- a/Assets/Scripts/PhysicsPlayerCarController2.cs
+++ b/Assets/Scripts/PhysicsPlayerCarController2.cs
@@ -7,7 +7,28 @@ public class PhysicsPlayerCarController2 : MonoBehaviour
     public float driftFactor = 0.4f;
     public float accelerationFactor = 30f;
     public float turnFactor = 3.5f;
+    
     public float baseMaxSpeed = 20f;
+
+    [Header("Car Turning Curve")]
+    public float steeringRefSpeed = 20f;
+    [SerializeField] 
+    private AnimationCurve steeringCurve = new AnimationCurve(
+        new Keyframe(0.00f, 0.00f),   // no steering when stopped
+        new Keyframe(0.35f, 1.00f),   // max steering around ~35% of ref speed
+        new Keyframe(0.80f, 0.60f),   // taper off at higher speeds
+        new Keyframe(1.00f, 0.45f)    // less steering at full speed
+    );
+
+    [Header("Car Acceleration Curve")]
+    [SerializeField] private float accelerationRefSpeed = 20f;
+    [SerializeField]
+    private AnimationCurve accelerationCurve = new AnimationCurve(
+        new Keyframe(0.00f, 0.3f),   // Weak start
+        new Keyframe(0.25f, 1.0f),   // Strongest pull around 25% of ref speed
+        new Keyframe(0.75f, 0.8f),   // Still strong at mid/high speeds
+        new Keyframe(1.00f, 0.2f)    // Falls off at top speed
+    );
 
     [Header("Health")]
     public int maxHealth = 100;
@@ -65,6 +86,9 @@ public class PhysicsPlayerCarController2 : MonoBehaviour
         audioSource = GetComponent<AudioSource>();
         if (audioSource == null)
             audioSource = gameObject.AddComponent<AudioSource>();
+
+        //Initialize rotation angle to match the editor's rotation
+        rotationAngle = rb.rotation;
     }
 
     void FixedUpdate()
@@ -142,15 +166,23 @@ public class PhysicsPlayerCarController2 : MonoBehaviour
         if (velocityVsUp < (-maxSpeed * 0.5f) && accelerationInput < 0)
             return;
 
-        Vector2 engineForce = accelerationFactor * accelerationInput * transform.up * boost;
+        float speedPercent = Mathf.Clamp01(rb.velocity.magnitude / accelerationRefSpeed);
+        float accelFactorCurve = accelerationCurve.Evaluate(speedPercent);
+
+        Vector2 engineForce = accelerationFactor * accelFactorCurve * accelerationInput * transform.up * boost;
         rb.AddForce(engineForce, ForceMode2D.Force);
     }
 
     void ApplySteering()
     {
-        float minTurningSpeedFactor = Mathf.Clamp01(rb.velocity.magnitude / 8);
+        float speedPercent = Mathf.Clamp01(rb.velocity.magnitude / steeringRefSpeed);
+
+        float steeringFactor = Mathf.Clamp01(steeringCurve.Evaluate(speedPercent));
+
         float directionMultiplier = (velocityVsUp >= 0) ? 1f : -1f;
-        rotationAngle -= steeringInput * turnFactor * minTurningSpeedFactor * directionMultiplier;
+
+        rotationAngle -= steeringInput * turnFactor * steeringFactor * directionMultiplier;
+
         rb.MoveRotation(rotationAngle);
     }
 
@@ -160,6 +192,7 @@ public class PhysicsPlayerCarController2 : MonoBehaviour
         float targetAngle = Mathf.Round(rb.rotation / 90f) * 90f;
         float smoothedAngle = Mathf.LerpAngle(rb.rotation, targetAngle, Time.fixedDeltaTime * straightenSpeed);
         rb.MoveRotation(smoothedAngle);
+        rotationAngle = rb.rotation;
     }
 
     void ReduceCarDrift()


### PR DESCRIPTION
Improve car handling, acceleration, and camera zoom; fix rotation bugs

Gameplay Updates:
- Reduced player and cop speeds; cops slightly faster unless player boosts
- Steering now scales with speed: minimal at very low/high speeds, strongest at mid-range and during boost
- Acceleration follows a curve: slow from standstill, more responsive as speed increases
- Camera zooms dynamically based on player speed

Bug Fixes:
- Fixed snapping to North at start (rotationAngle now initialized in Awake)
- Fixed Ctrl-based steering straighten resetting; rotationAngle now updates to match straightened rotation